### PR TITLE
fix: rendering error on tweets containing emoji or non-BMP characters

### DIFF
--- a/src/service/twitter/render/basic/image.tsx
+++ b/src/service/twitter/render/basic/image.tsx
@@ -786,38 +786,38 @@ export class RenderTweetImage {
 
     const normalizeHashtags = [...(noteEntity?.hashtags ?? []), ...(legacySet?.hashtags ?? [])].map(
       ({indices, tag}) => ({
-        start: normalizeMap.findIndex(({array}) => array === indices[0]),
-        end: normalizeMap.findIndex(({array}) => array === indices[1]),
+        start: normalizeMap.findIndex(({str}) => str === indices[0]),
+        end: normalizeMap.findIndex(({str}) => str === indices[1]),
         tag,
       }),
     )
 
     const normalizeMedia = [...(extEntities?.media ?? [])].map(({indices, idStr, mediaUrlHttps, type}) => ({
-      start: normalizeMap.findIndex(({array}) => array === indices[0]),
-      end: normalizeMap.findIndex(({array}) => array === indices[1]),
+      start: normalizeMap.findIndex(({str}) => str === indices[0]),
+      end: normalizeMap.findIndex(({str}) => str === indices[1]),
       remove: video && type !== 'photo',
       idStr,
       mediaUrlHttps,
     }))
 
     const normalizeNoteMedia = [...(noteEntity?.media ?? [])].map(({indices, idStr, mediaUrlHttps, type}) => ({
-      start: normalizeMap.findIndex(({array}) => array === indices[0]),
-      end: normalizeMap.findIndex(({array}) => array === indices[1]),
+      start: normalizeMap.findIndex(({str}) => str === indices[0]),
+      end: normalizeMap.findIndex(({str}) => str === indices[1]),
       remove: video && type !== 'photo',
       idStr,
       mediaUrlHttps,
     }))
 
     const normalizeUrls = [...(noteEntity?.urls ?? []), ...(legacySet?.urls ?? [])].map(({indices, displayUrl}) => ({
-      start: normalizeMap.findIndex(({array}) => array === indices[0]),
-      end: normalizeMap.findIndex(({array}) => array === indices[1]),
+      start: normalizeMap.findIndex(({str}) => str === indices[0]),
+      end: normalizeMap.findIndex(({str}) => str === indices[1]),
       displayUrl,
     }))
 
     const normalizeUserMentions = [...(noteEntity?.userMentions ?? []), ...(legacySet?.userMentions ?? [])].map(
       ({indices, screenName}) => ({
-        start: normalizeMap.findIndex(({array}) => array === indices[0]),
-        end: normalizeMap.findIndex(({array}) => array === indices[1]),
+        start: normalizeMap.findIndex(({str}) => str === indices[0]),
+        end: normalizeMap.findIndex(({str}) => str === indices[1]),
         screenName,
       }),
     )


### PR DESCRIPTION
## Problem

Rendering fails on tweets that contain emoji or other characters outside the Basic Multilingual Plane (e.g. "🍊 is the new 🍋").

Repro: https://twitter.com/elonmusk/status/1770222178279252062

## Root Cause

In `tweetRender()`, the `normalizeMap` is built with two fields per grapheme cluster:

- `array` — cumulative grapheme cluster count (emoji = 1)
- `str` — cumulative UTF-16 code unit count (emoji = 2)

Twitter API returns `entities.indices` based on **UTF-16 code units**. However, the code was looking up those indices against the `array` field instead of `str`. Once any emoji appears in the text, `array` and `str` diverge, causing `findIndex()` to return `-1` for subsequent entities, which breaks the rendering logic.

For example, with the text `"🍊 is the new 🍋"`:

| position | array | str |
|----------|-------|-----|
| after 🍊 | 1     | 2   |
| after 🍋 | 14    | 16  |

If the API returns `indices = [14, 16]`, searching by `array === 16` returns `-1`, crashing the renderer.

Note that `normalizeRichtextTags` and `normalizeInlineMedia` were already using `str` correctly — this fix brings the remaining five lookups in line with that.

## Fix

Changed `array` → `str` in five places within `tweetRender()`:

- `normalizeHashtags`
- `normalizeMedia`
- `normalizeNoteMedia`
- `normalizeUrls`
- `normalizeUserMentions`